### PR TITLE
Fixes to perfectObs for flr/flcore#50

### DIFF
--- a/R/MP_1a_Observation_Model.R
+++ b/R/MP_1a_Observation_Model.R
@@ -58,8 +58,8 @@ perfectObs <- function(biol, fleets, covars, obs.ctrl, year = 1, season = NULL, 
     res <- as(biol, 'FLStock')[,1:(year-1),1,1]
     dimnames(res) <- list(unit="unique")
     
-    res@range[c(1:3,6:7)] <- biol@range[c(1:3,6:7)]
-    names(res@range[6:7]) <- c('minfbar', 'maxfbar')
+    #res@range[c(1:3,6:7)] <- biol@range[c(1:3,6:7)]
+    #names(res@range[6:7]) <- c('minfbar', 'maxfbar')
         
     res@discards.wt <- res@landings.wt <- res@catch.wt <- res@stock.wt
         
@@ -105,7 +105,7 @@ perfectObs <- function(biol, fleets, covars, obs.ctrl, year = 1, season = NULL, 
     # harvest: * if age structured calculate it from 'n'.
     #          * if biomass dyn => assume C = q*E*B => C = F*B and F = C/B.
     if(na == 1){
-        harvest(res) <- res@catch/(res@stock.n*res@stock.wt)
+        harvest(res) <- (res@stock.n*res@stock.wt) * (1 / res@catch)
         units(res@harvest) <- 'hr'
     } else{
         harvest(res) <- catch.n(res)*NA #! Artefact to avoid crashing (sets correct dim for iters)
@@ -156,7 +156,6 @@ perfectObs <- function(biol, fleets, covars, obs.ctrl, year = 1, season = NULL, 
     }
     
     # If catc
-
     return(res)
 }
  


### PR DESCRIPTION
No need for setting minfbar and maxfbar in FLStock from FLBiol after [this commit](https://github.com/flr/FLCore/commit/33f5eaebfbd20acbf439fded53a8751cba8c72e4) in FLCore.

Also, changing the order of the hr calculation deals with units breaking FLStock validity.