### PR TITLE
adjustments to fltStkSum, making more efficient returning of results …

### DIFF
--- a/R/Results_Summary.R
+++ b/R/Results_Summary.R
@@ -1036,14 +1036,18 @@ totfcost_flbeia <- function(fleet, covars, flnm = NULL){
 #------------------------------------------------------------------------------#
 #' @rdname bioSum
 #' @aliases fltStkSum
-fltStkSum <- function(obj, flnms = names(obj$fleets), stknms = catchNames(obj$fleets), years = dimnames(obj$biols[[1]]@n)[[2]], byyear = TRUE, long = FALSE, scenario = 'bc'){
+fltStkSum <- function(obj, flnms = names(obj$fleets), 
+  stknms = catchNames(obj$fleets), 
+  years = dimnames(obj$biols[[1]]@n)[[2]], 
+  byyear = TRUE, long = FALSE, scenario = 'bc', 
+  verbose = TRUE){
   
   fleets <- obj$fleets
   advice <- obj$advice
   
   #  fleets <- lapply(fleets, setUnitsNA)
-  
-  warning('Due to a problem with the units attribute in some off the slots, sometimes this function crashes. In case it fails, we recommend 
+
+  warning('Due to a problem with the units attribute in some off the slots, sometimes this function crashes. In case it fails, we recommend
           removing the units using the setUnitsNA function')
   
   if(flnms[1] == 'all') flnms <- names(fleets)
@@ -1052,9 +1056,8 @@ fltStkSum <- function(obj, flnms = names(obj$fleets), stknms = catchNames(obj$fl
   Dim   <- dim(fleets[[1]]@effort[,years,])[c(2,4,6)]
   Dimnm <- dimnames(fleets[[1]]@effort[,years,])
   
-  res <- NULL
-  
-  
+  resfl <- vector("list", length(flnms))
+  names(resfl) <- flnms
   if(byyear == FALSE){ 
     
     year = rep(years, prod(Dim[2:3])) 
@@ -1068,6 +1071,8 @@ fltStkSum <- function(obj, flnms = names(obj$fleets), stknms = catchNames(obj$fl
       stfl <- catchNames(fl)        
       sts   <- stknms[stknms %in% stfl]
       
+      resflst <- vector("list", length(sts))
+      names(resflst) <- sts
       for(st in sts){
  
         # fl <- fleets[[f]]
@@ -1083,8 +1088,12 @@ fltStkSum <- function(obj, flnms = names(obj$fleets), stknms = catchNames(obj$fl
                  tacshare=c(advice$quota.share[[st]][f,][,years]),
                  quota=c((advice$TAC[st,]*advice$quota.share[[st]][f,])[,years]),
                  quotaUpt=catch/quota)
-        res <- bind_rows(res,res.fl.st)
-      }}
+        resflst[[st]] <- res.fl.st
+        if(verbose){print(paste("| fleet =", f, "|", "stock =", st, "|"))}
+      }
+      resfl[[f]] <- do.call("rbind", resflst)
+    }
+    res <- do.call("rbind", resfl)
   }  else{
     
     year = rep(years, Dim[3]) 
@@ -1096,6 +1105,9 @@ fltStkSum <- function(obj, flnms = names(obj$fleets), stknms = catchNames(obj$fl
       stfl <- catchNames(fl)        
       sts   <- stknms[stknms %in% stfl]
       fleet = rep(f, each = prod(Dim[-2]))
+      
+      resflst <- vector("list", length(sts))
+      names(resflst) <- sts
       
       for(st in sts){
         
@@ -1110,8 +1122,12 @@ fltStkSum <- function(obj, flnms = names(obj$fleets), stknms = catchNames(obj$fl
                  tacshare=c(advice$quota.share[[st]][f,][,years]),
                  quota=c((advice$TAC[st,]*advice$quota.share[[st]][f,])[,years]),
                  quotaUpt=catch/quota)
-        res <- bind_rows(res,res.fl.st)
-      }}
+        resflst[[st]] <- res.fl.st
+        if(verbose){print(paste("| fleet =", f, "|", "stock =", st, "|"))}
+      }
+      resfl[[f]] <- do.call("rbind", resflst)
+    }
+    res <- do.call("rbind", resfl)
   }
   
   if(long == TRUE){ # transform res into long format
@@ -1124,7 +1140,7 @@ fltStkSum <- function(obj, flnms = names(obj$fleets), stknms = catchNames(obj$fl
   
   return(res)
 } 
-                               
+
 
 # fltStkSumQ 
 #' @rdname bioSum


### PR DESCRIPTION
The fltStkSum function was quite slow when applied to the North Sea model due to a large number of fleets and stocks. I made a small adjustment to the function that sets up an empty results list with levels for each fleet, which is then filled. This prevents the growing of the results object, where its memory allocation needs to be constantly updated.  