### PR TITLE
Markov model predictions in SMFB_VarEffort fixed

### DIFF
--- a/R/OM_2a_Effort_Dynamics_SMFB_VarEffortShare.R
+++ b/R/OM_2a_Effort_Dynamics_SMFB_VarEffortShare.R
@@ -766,8 +766,9 @@ land$effort <- eff$data[match(land$metier, eff$metier)]
 land$lpue   <- land$data / land$effort 
 
 
-  for(st in catchNames(fleet)) {
-      predict.df[,st] <-land[land$stock == st, "lpue"]
+  for(st in colnames(predict.df)) {
+	  
+     predict.df[,st] <-land[land$stock == st, "lpue"]
      # CR[CR$stock == st,2]  ## This will repeat, to ensure we get for each metier combinations
     }
     predict.df[is.na(predict.df)] <- 0

--- a/R/OM_2a_Effort_Dynamics_SMFB_VarEffortShare.R
+++ b/R/OM_2a_Effort_Dynamics_SMFB_VarEffortShare.R
@@ -766,7 +766,7 @@ land$effort <- eff$data[match(land$metier, eff$metier)]
 land$lpue   <- land$data / land$effort 
 
 
-  for(st in unique(CR$stock)) {
+  for(st in unique(land$stock)) {
       predict.df[,st] <-land[land$stock == st, "lpue"]
      # CR[CR$stock == st,2]  ## This will repeat, to ensure we get for each metier combinations
     }

--- a/R/OM_2a_Effort_Dynamics_SMFB_VarEffortShare.R
+++ b/R/OM_2a_Effort_Dynamics_SMFB_VarEffortShare.R
@@ -767,8 +767,9 @@ land$lpue   <- land$data / land$effort
 
 
   for(st in colnames(predict.df)) {
-	  
-     predict.df[,st] <-land[land$stock == st, "lpue"]
+	 
+     predict.df[predict.df$state.tminus1 %in% land[land$stock == st, "metier"],st] <- land[land$stock == st, "lpue"]
+     #predict.df[,st] <- land[land$stock == st, "lpue"]
      # CR[CR$stock == st,2]  ## This will repeat, to ensure we get for each metier combinations
     }
     predict.df[is.na(predict.df)] <- 0

--- a/R/OM_2a_Effort_Dynamics_SMFB_VarEffortShare.R
+++ b/R/OM_2a_Effort_Dynamics_SMFB_VarEffortShare.R
@@ -766,7 +766,7 @@ land$effort <- eff$data[match(land$metier, eff$metier)]
 land$lpue   <- land$data / land$effort 
 
 
-  for(st in unique(land$stock)) {
+  for(st in catchNames(fleet)) {
       predict.df[,st] <-land[land$stock == st, "lpue"]
      # CR[CR$stock == st,2]  ## This will repeat, to ensure we get for each metier combinations
     }


### PR DESCRIPTION
The Markov predictions were picking up catch rates in the _current season_, but the model should be fitted to the departing metier, i.e. the catch rates in the previous season. This change fixes that, testing as behaving as expected.