### PR TITLE
Max prof edit

### DIFF
--- a/R/OM_2a_Effort_Dynamics_MaxProf.R
+++ b/R/OM_2a_Effort_Dynamics_MaxProf.R
@@ -46,7 +46,7 @@ MaxProfit <- function(fleets, biols, BDs,covars, advice, biols.ctrl, fleets.ctrl
   
   # Fleet's info
   fl    <- fleets[[flnm]]
-  sts   <- catchNames(fl)
+  sts   <- intersect(fleets.ctrl[[flnm]][['stocks.restr']], catchNames(fl))
   mtnms <- names(fl@metiers)
   nmt   <- length(mtnms)
   


### PR DESCRIPTION
The following edits fix one critical issue and one enhancement. The issue was in the definition of restricting stocks for a given fleet  (`sts`), which was defined inconsistently between `MaxProfit` and `FLObjs2S3_fleetSTD`. The enhancement was to use `try` with the call to `optim`, whereby the original metier effort share values are retained in the case of an error in the fitting. 
