### PR TITLE
Ices hcr fix

### DIFF
--- a/R/MP_3c_HCR_ICES_MSY.R
+++ b/R/MP_3c_HCR_ICES_MSY.R
@@ -189,7 +189,7 @@ IcesHCR <- function(stocks, advice, advice.ctrl, year, stknm,...){
         k <- which(fwd.ctrl@target$year == assyrnumb+1)
         fwd.ctrl@target[k,'val'] <- Ftg
         fwd.ctrl@trgtArray[k, 'val',] <- Ftg
-        stki <- fwdBD(stki, fwd.ctrl, growth.years)
+        stki <- fwdBD(stki, fwd.ctrl, growth.years) 
         
       }
      


### PR DESCRIPTION
Hello,

I'm requesting a pull for the following changes to the `IcesHCR()` function. 

I noticed that the function incorrectly uses the SSB from assessment_year-1, rather than assessment_year+1. Since the function already included a short-term forecast with the intermediate year assumption (using `fwd()`), it was relatively easy to call the HCR again with the new SSB projected for the advice year. Using this new `Ftg`, the `fwd_control` is updated and second short-term forecast is done to determine the TAC in the advice year (see L155-167, and L180-192).

Cheers, Marc