### PR TITLE
fix iterations subsetting for TAC

### DIFF
--- a/R/OM_2a_Effort_Dynamics_Auxiliary.R
+++ b/R/OM_2a_Effort_Dynamics_Auxiliary.R
@@ -132,7 +132,7 @@ FLObjs2S3_fleetSTD <- function(biols, fleets, BDs, advice, covars, biols.ctrl, f
     # if rho is a numeric => there is only one stock and one iteration wihout names => name it
     # [nst,it]
     #------------------------------------------------------------------------------------------
-    TAC.yr  <- matrix(advice$TAC[stnms,yr,drop=T], nst, nit, dimnames = list(stnms, iters))   # [nst,it]
+    TAC.yr  <- matrix(advice$TAC[stnms,yr,,,,iters,drop=T], nst, nit, dimnames = list(stnms, iters))   # [nst,it]
     # when advice season is different to ns: adapt to the advice calendar 
     for (st in stnms)
       if (adv.ss[st] < ns & ss <= adv.ss[st]) TAC.yr[st,] <- advice$TAC[st,yr-1,drop=T] # previous year TAC


### PR DESCRIPTION
Edited FLObjs2S3_fleetSTD to subset TAC advice object by the iterations provided. Avoid bug where for single iteration operations, only TAC for first iteration is returned. This was only an issue for MaxProfit effort function (where FLObjs2S3_fleetSTD was called iteratively within a loop).